### PR TITLE
Add context-team management routines

### DIFF
--- a/content/shmem_ctx_create.tex
+++ b/content/shmem_ctx_create.tex
@@ -25,6 +25,15 @@ int @\FuncDecl{shmem\_ctx\_create}@(long options, shmem_ctx_t *ctx);
     in a correct state.  The creation call can be reattempted with different
     options or after additional resources become available.
 
+    \newtext{
+    A newly created communication context has an initial association with the
+    default team.
+    All \openshmem routines that operate on this context will do so with
+    respect to the associated \ac{PE} team.
+    That is, all point-to-point routines operating on this context will use
+    team-relative \ac{PE} numbering.
+    }
+
     By default, contexts are {\em shareable} and, when it is allowed by the
     threading model provided by the \openshmem library, they can be used concurrently by
     multiple threads within the PE where they were created.

--- a/content/shmem_ctx_destroy.tex
+++ b/content/shmem_ctx_destroy.tex
@@ -18,6 +18,11 @@ void @\FuncDecl{shmem\_ctx\_destroy}@(shmem_ctx_t ctx);
     the context is not used after it has been destroyed, for example when the
     destroyed context is used by multiple threads.  This function
     performs an implicit quiet operation on the given context before it is freed.
+
+    \newtext{
+    When a context is destroyed, the team associated with this context
+    is not affected.
+    }
 }
 
 \apireturnvalues{

--- a/content/shmem_ctx_get_team.tex
+++ b/content/shmem_ctx_get_team.tex
@@ -36,6 +36,13 @@ int @\FuncDecl{shmem\_ctx\_get\_team}@(shmem_ctx_t ctx, shmem_team_t *team);
 
   \apireturnvalues{
     Zero on success; otherwise, \CONST{-1}.
+
+    \begin{FeedbackRequest}
+      Should this routine return nonzero, -1, or negative values
+      (e.g., to allow for implementation-defined error codes) on error?
+      Will slowing down the critical path of this routine by adding
+      input checking adversely affect its use?
+    \end{FeedbackRequest}
   }
 
   \apinotes{

--- a/content/shmem_ctx_get_team.tex
+++ b/content/shmem_ctx_get_team.tex
@@ -1,0 +1,45 @@
+\apisummary{
+  Retrieve the team associated with the communication context.
+}
+
+\begin{apidefinition}
+
+  \begin{Csynopsis}
+int @\FuncDecl{shmem\_ctx\_get\_team}@(shmem_ctx_t ctx, shmem_team_t *team);
+  \end{Csynopsis}
+
+  \begin{apiarguments}
+
+    \apiargument{IN}{ctx}{
+      A handle to a communication context.
+    }
+
+    \apiargument{OUT}{team}{
+      A pointer to a handle to the associated \ac{PE} team.
+    }
+
+  \end{apiarguments}
+
+  \apidescription{
+    The \FUNC{shmem\_ctx\_get\_team} routine returns a handle to the \ac{PE}
+    team associated with the specified communication context \VAR{ctx}.
+    The team handle is returned through the pointer argument \VAR{team}.
+
+    If \VAR{ctx} is the default context, the returned team is guaranteed
+    to be \CONST{SHMEM\_TEAM\_WORLD}.
+
+    If \VAR{ctx} is an invalid context, the argument \VAR{team} is not
+    modified and a value of \CONST{-1} is returned.
+
+    If \VAR{team} is a null pointer, a value of \CONST{-1} is returned.
+  }
+
+  \apireturnvalues{
+    Zero on success; otherwise, \CONST{-1}.
+  }
+
+  \apinotes{
+    None.
+  }
+
+\end{apidefinition}

--- a/content/shmem_ctx_set_team.tex
+++ b/content/shmem_ctx_set_team.tex
@@ -36,6 +36,13 @@ int @\FuncDecl{shmem\_ctx\_set\_team}@(shmem_ctx_t ctx, shmem_team_t team);
 
   \apireturnvalues{
     Zero on success; otherwise, \CONST{-1}.
+
+    \begin{FeedbackRequest}
+      Should this routine return nonzero, -1, or negative values
+      (e.g., to allow for implementation-defined error codes) on error?
+      Will slowing down the critical path of this routine by adding
+      input checking adversely affect its use?
+    \end{FeedbackRequest}
   }
 
   \apinotes{

--- a/content/shmem_ctx_set_team.tex
+++ b/content/shmem_ctx_set_team.tex
@@ -1,0 +1,45 @@
+\apisummary{
+  Update the team associated with the communication context.
+}
+
+\begin{apidefinition}
+
+  \begin{Csynopsis}
+int @\FuncDecl{shmem\_ctx\_set\_team}@(shmem_ctx_t ctx, shmem_team_t team);
+  \end{Csynopsis}
+
+  \begin{apiarguments}
+
+    \apiargument{IN}{ctx}{
+      A handle to a communication context.
+    }
+
+    \apiargument{IN}{team}{
+      A handle to the specified \ac{PE} team.
+    }
+
+  \end{apiarguments}
+
+  \apidescription{
+    The \FUNC{shmem\_ctx\_set\_team} routine associates the \ac{PE} team
+    identified by the handle \VAR{team} with the communication context
+    specified by the handle \VAR{ctx}.
+    All subsequent \openshmem operations performed on the specified context
+    will operate with respect to the updated \ac{PE} team.
+
+    If \VAR{ctx} is a handle to the default context or
+    \VAR{team} is equal to the constant \CONST{SHMEM\_TEAM\_NULL}, then
+    the specified context is not updated and a value of \CONST{-1} is returned.
+
+    If \VAR{ctx} is an invalid context, a value of \CONST{-1} is returned.
+  }
+
+  \apireturnvalues{
+    Zero on success; otherwise, \CONST{-1}.
+  }
+
+  \apinotes{
+    None.
+  }
+
+\end{apidefinition}

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -135,6 +135,18 @@ routines.  API routines that do not accept a context argument operate on the
 default context.  The default context can be used explicitly through the
 \LibHandleRef{SHMEM\_CTX\_DEFAULT} handle.
 
+\newtext{
+Every communication context has an associated \ac{PE} team.
+This \ac{PE} team specifies the set of \acp{PE} over which \ac{PE}-specific
+routines that operate on a communication context, explicitly or implicitly,
+(e.g., \ac{RMA} and \ac{AMO} routines) may be performed.
+The default context has a fixed association with the world team,
+\LibHandleRef{SHMEM\_TEAM\_WORLD}.
+Communication contexts created by \FUNC{shmem\_ctx\_create} have an initial
+association with the world team, which may be updated by the
+\FUNC{shmem\_ctx\_set\_team} routine.
+}
+
 \subsubsection{\textbf{SHMEM\_CTX\_CREATE}}
 \label{subsec:shmem_ctx_create}
 \input{content/shmem_ctx_create.tex}
@@ -142,6 +154,18 @@ default context.  The default context can be used explicitly through the
 \subsubsection{\textbf{SHMEM\_CTX\_DESTROY}}
 \label{subsec:shmem_ctx_destroy}
 \input{content/shmem_ctx_destroy.tex}
+
+\newtext{
+\subsubsection{\textbf{SHMEM\_CTX\_SET\_TEAM}}
+\label{subsec:shmem_ctx_set_team}
+\input{content/shmem_ctx_set_team.tex}
+}
+
+\newtext{
+\subsubsection{\textbf{SHMEM\_CTX\_GET\_TEAM}}
+\label{subsec:shmem_ctx_get_team}
+\input{content/shmem_ctx_get_team.tex}
+}
 
 
 \subsection{Remote Memory Access Routines}\label{sec:rma}

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -140,10 +140,14 @@ Every communication context has an associated \ac{PE} team.
 This \ac{PE} team specifies the set of \acp{PE} over which \ac{PE}-specific
 routines that operate on a communication context, explicitly or implicitly,
 (e.g., \ac{RMA} and \ac{AMO} routines) may be performed.
-The default context has a fixed association with the world team,
-\LibHandleRef{SHMEM\_TEAM\_WORLD}.
+All \openshmem routines that operate on this context will do so with respect
+to the team-relative \ac{PE} numbering of the associated \ac{PE} team.
+}
+
+\newtext{
+The default context has a fixed association with the default team.
 Communication contexts created by \FUNC{shmem\_ctx\_create} have an initial
-association with the world team, which may be updated by the
+association with the default team, which may be updated by the
 \FUNC{shmem\_ctx\_set\_team} routine.
 }
 

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -408,14 +408,16 @@
   \textbf{C11:} 
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
-    morekeywords={size_t, ptrdiff_t, TYPE, _Noreturn, shmem_ctx_t},
+    morekeywords={size_t, ptrdiff_t, TYPE, _Noreturn, shmem_ctx_t,
+      shmem_team_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisCol}
 { 
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
-    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t},
+    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t,
+      shmem_team_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 
@@ -424,7 +426,8 @@
   \textbf{C/C++:} 
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
-    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t},
+    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t,
+      shmem_team_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisST}
@@ -433,7 +436,8 @@
   \color{red}  
   {\lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
-    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t},
+    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t,
+      shmem_team_t},
     aboveskip=0pt, belowskip=0pt}}}{}
 
 \lstnewenvironment{Fsynopsis}
@@ -516,7 +520,7 @@
     ##1
     \lstinputlisting[language={C}, tabsize=2,
       basicstyle=\ttfamily\footnotesize,
-      morekeywords={size_t, ptrdiff_t, shmem_ctx_t}]{##2}
+      morekeywords={size_t, ptrdiff_t, shmem_ctx_t, shmem_team_t}]{##2}
     ##3 }
 \newcommand{\apifexample}[3]{
     ##1

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -360,7 +360,6 @@
   {\strikeline\mbox{} \DeprecationStart \stretchline\mbox{}}}
 \newcommand{\EndDeprecateBlock}{%
   \mbox{}\stretchline\mbox{} \DeprecationEnd \strikeline}
-
 \newenvironment{DeprecateBlock}{%
   \par \StartDeprecateBlock \par}{\par \EndDeprecateBlock \par}
 
@@ -370,16 +369,25 @@
   \strikeline\mbox{} \DeprecationEnd \strikeline}
 \newenvironment{DeprecateInline}{\StartInlineDeprecate}{\EndInlineDeprecate}
 
+\newcommand{\deprecationstart}{%
+  \color{red} \strikeline\mbox{} deprecation start \stretchline \mbox{}}
+\newcommand{\deprecationend}{%
+  \mbox{}\stretchline\mbox{} \color{red} deprecation end \strikeline}
+\newenvironment{deprecate}{\deprecationstart \\}{\\ \deprecationend}
+
+%
+% Design feedback request helpers
+%
+
+\newcommand{\feedbackstart}{\color{RoyalBlue} \strikeline[RoyalBlue]
+  design feedback requested \stretchline[RoyalBlue] \mbox{}}
+\newcommand{\feedbackend}{\mbox{}\stretchline[RoyalBlue]\mbox{}}
+
+\newenvironment{FeedbackRequest}{\feedbackstart \\}{\\ \feedbackend}
+
 %
 % Library API description template commands
 %
-
-\newcommand{\deprecationstart}{\color{red} \raisebox{.5ex}{\rule{1em}{.4pt}}
-  deprecation start \xrfill[.5ex]{.4pt}[red] \mbox{}}
-\newcommand{\deprecationend}{\mbox{}\xrfill[.5ex]{.4pt}[red]\mbox{} \color{red}
-  deprecation end \raisebox{.5ex}{\rule{1em}{.4pt}}}
-
-\newenvironment{deprecate}{\deprecationstart \\}{\\ \deprecationend}
 
 \newcommand{\apisummary}[1]{
     #1


### PR DESCRIPTION
Resolve #9 

Adds `shmem_ctx_{get,set}_team` and some introductory text relating contexts and teams -- the latter of which will probably need expansion.