### PR TITLE
Add an updated shmem_sync example using teams API

### DIFF
--- a/example_code/shmem_sync_example.c
+++ b/example_code/shmem_sync_example.c
@@ -9,8 +9,8 @@ int main(void)
    shmem_team_config_t *config;
 
    shmem_init();
-   config = NULL;
-   int me = shmem_my_pe();
+   config   = NULL;
+   int me   = shmem_my_pe();
    int npes = shmem_n_pes();
 
    int odd_npes = npes % 2;
@@ -18,7 +18,8 @@ int main(void)
    shmem_team_split_strided(SHMEM_TEAM_WORLD, 0, 2, npes / 2, config, 0,
                             &twos_team);
 
-   /* The teams overlap, so synchronize on the parent team */
+   /* The "threes" team below overlaps with the "twos" team, so
+    * synchronize on the parent team */
    shmem_sync(SHMEM_TEAM_WORLD);
 
    shmem_team_split_strided(SHMEM_TEAM_WORLD, 0, 3, npes / 3 + odd_npes,


### PR DESCRIPTION
Here is a `shmem_sync` example that I've updated to use a couple of simple teams.

Hopefully this is helpful - please don't hesitate to propose suggestions/alternatives/fixes.

~~Also, I am a little unsure whether it's safe to leave the `shmem_team_config_t` object uninitialized during team creation since the mask is zero.  The current specification draft suggests to me that there is no need to set the configuration struct if the mask is zero, but I just want to make sure.~~  Passing NULL pointer instead...

Signed-off-by: David M. Ozog <david.m.ozog@intel.com>