### PR TITLE
Typed Collectives with minimal examples

### DIFF
--- a/content/collective_intro.tex
+++ b/content/collective_intro.tex
@@ -45,12 +45,12 @@ The team-based collective routines defined in the \openshmem Specification are:
 
 \begin{itemize}
 \item \FUNC{shmem\_team\_sync}
-\item \FUNC{shmem\_team\_broadcast\{32, 64\}}
-\item \FUNC{shmem\_team\_collect\{32, 64\}}
-\item \FUNC{shmem\_team\_fcollect\{32, 64\}}
+\item \FUNC{shmem\_team\_broadcast}
+\item \FUNC{shmem\_team\_collect}
+\item \FUNC{shmem\_team\_fcollect}
 \item Reductions for the following operations: AND, MAX, MIN, SUM, PROD, OR, XOR
-\item \FUNC{shmem\_team\_alltoall\{32, 64\}}
-\item \FUNC{shmem\_team\_alltoalls\{32, 64\}}
+\item \FUNC{shmem\_team\_alltoall}
+\item \FUNC{shmem\_team\_alltoalls}
 \end{itemize}
 
 In addition, all team creation functions are collective operations. In addition to the ordering

--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -7,18 +7,18 @@
 %% C11
 {\color{Green}
 \begin{C11synopsis}
-int @\FuncDecl{shmem\_alltoall32}@(void *dest, const void *source, size_t nelems, shmem_team_t team);
-int @\FuncDecl{shmem\_alltoall64}@(void *dest, const void *source, size_t nelems, shmem_team_t team);
+int @\FuncDecl{shmem\_alltoall}@(TYPE *dest, const TYPE *source, size_t nelems, shmem_team_t team);
 \end{C11synopsis}
+where \TYPE{} is one of the standard \ac{RMA} types specified by Table
+\ref{stdrmatypes}.
 }
 
-\begin{Csynopsis}
-\end{Csynopsis}
 {\color{Green}
-\begin{CsynopsisCol}
-int @\FuncDecl{shmem\_team\_alltoall32}@(void *dest, const void *source, size_t nelems, shmem_team_t team);
-int @\FuncDecl{shmem\_team\_alltoall64}@(void *dest, const void *source, size_t nelems, shmem_team_t team);
-\end{CsynopsisCol}
+\begin{Csynopsis}
+int @\FuncDecl{shmem\_team\_\FuncParam{TYPENAME}\_alltoall}@(TYPE *dest, const TYPE *source, size_t nelems, shmem_team_t team);
+\end{Csynopsis}
+where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding
+\TYPENAME{} specified by Table \ref{stdrmatypes}.
 }
 
 \begin{DeprecateBlock}
@@ -37,10 +37,10 @@ CALL @\FuncDecl{SHMEM\_ALLTOALL64}@(dest, source, nelems, PE_start, logPE_stride
 
 \begin{apiarguments}
 
-\apiargument{OUT}{dest}{A symmetric data object large enough to receive
+\apiargument{OUT}{dest}{A remotely accessible data object large enough to receive
     the combined total of \VAR{nelems} elements from each \ac{PE} in the
     active set.}
-\apiargument{IN}{source}{A symmetric data object that contains \VAR{nelems}
+\apiargument{IN}{source}{A remotely accessible data object that contains \VAR{nelems}
     elements of data for each \ac{PE} in the active set, ordered according to
     destination \ac{PE}.}
 \apiargument{IN}{nelems}{The number of elements to exchange for each \ac{PE}.
@@ -75,13 +75,13 @@ CALL @\FuncDecl{SHMEM\_ALLTOALL64}@(dest, source, nelems, PE_start, logPE_stride
 \apidescription{
     The \FUNC{shmem\_alltoall} routines are collective routines. Each \ac{PE}
     \oldtext{in the active set} \newtext{participating in the operation}
-    exchanges \VAR{nelems} data elements of size
-    32 bits (for \FUNC{shmem\_alltoall32}) or 64 bits (for \FUNC{shmem\_alltoall64})
+    exchanges \VAR{nelems} data elements \oldtext{of size
+    32 bits (for \FUNC{shmem\_alltoall32}) or 64 bits (for \FUNC{shmem\_alltoall64})}
     with all other \acp{PE} \oldtext{in the set}
     \newtext{participating in the operation}. The data being sent and received are
     stored in a contiguous symmetric data object. The total size of each \acp{PE}
     \VAR{source} object and \VAR{dest} object is \VAR{nelems} times the size of
-    an element (32 bits or 64 bits) times \oldtext{\VAR{PE\_size}}
+    an element \oldtext{(32 bits or 64 bits)} times \oldtext{\VAR{PE\_size}}
     \newtext{\VAR{N}, where \VAR{N} equals the number of \acp{PE} participating
     in the operation}.
     The \VAR{source} object contains oldtext{\VAR{PE\_size}} \VAR{N} blocks of data
@@ -139,6 +139,7 @@ CALL @\FuncDecl{SHMEM\_ALLTOALL64}@(dest, source, nelems, PE_start, logPE_stride
     \end{itemize}
 }
 
+\begin{DeprecateBlock}
 \apidesctable{
 The  \dest{}  and \source{} data  objects must conform to certain typing
 constraints, which are as follows:
@@ -146,6 +147,7 @@ constraints, which are as follows:
 
 \apitablerow{shmem\_alltoall64}{\CONST{64} bits aligned.}
 \apitablerow{shmem\_alltoall32}{\CONST{32} bits aligned.}
+\end{DeprecateBlock}
 
 \apireturnvalues{
     \newtext{Zero on successful local completion. Nonzero otherwise.}

--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -37,10 +37,10 @@ CALL @\FuncDecl{SHMEM\_ALLTOALL64}@(dest, source, nelems, PE_start, logPE_stride
 
 \begin{apiarguments}
 
-\apiargument{OUT}{dest}{A remotely accessible data object large enough to receive
+\apiargument{OUT}{dest}{A symmetric data object large enough to receive
     the combined total of \VAR{nelems} elements from each \ac{PE} in the
     active set.}
-\apiargument{IN}{source}{A remotely accessible data object that contains \VAR{nelems}
+\apiargument{IN}{source}{A symmetric data object that contains \VAR{nelems}
     elements of data for each \ac{PE} in the active set, ordered according to
     destination \ac{PE}.}
 \apiargument{IN}{nelems}{The number of elements to exchange for each \ac{PE}.
@@ -182,7 +182,7 @@ constraints, which are as follows:
 \begin{apiexamples}
 
 \apicexample
-    {This example shows a \FUNC{shmem\_alltoall64} on two long elements among all
+    {This \Cstd[11] example shows a \FUNC{shmem\_alltoall} on two 64-bit integers among all
     \acp{PE}.}
     {./example_code/shmem_alltoall_example.c}
     {}

--- a/content/shmem_alltoalls.tex
+++ b/content/shmem_alltoalls.tex
@@ -7,18 +7,18 @@
 %% C11
 {\color{Green}
 \begin{C11synopsis}
-int @\FuncDecl{shmem\_alltoall32}@(void *dest, const void *source, size_t nelems, shmem_team_t team);
-int @\FuncDecl{shmem\_alltoall64}@(void *dest, const void *source, size_t nelems, shmem_team_t team);
+int @\FuncDecl{shmem\_alltoalls}@(TYPE *dest, const TYPE *source, ptrdiff_t dst, ptrdiff_t sst, size_t nelems, shmem_team_t team);
 \end{C11synopsis}
+where \TYPE{} is one of the standard \ac{RMA} types specified by Table
+\ref{stdrmatypes}.
 }
 
-\begin{Csynopsis}
-\end{Csynopsis}
 {\color{Green}
-\begin{CsynopsisCol}
-int @\FuncDecl{shmem\_team\_alltoall32}@(void *dest, const void *source, size_t nelems, shmem_team_t team);
-int @\FuncDecl{shmem\_team\_alltoall64}@(void *dest, const void *source, size_t nelems, shmem_team_t team);
-\end{CsynopsisCol}
+\begin{Csynopsis}
+int @\FuncDecl{shmem\_team\_\FuncParam{TYPENAME}\_alltoalls}@(TYPE *dest, const TYPE *source, ptrdiff_t dst, ptrdiff_t sst, size_t nelems, shmem_team_t team);
+\end{Csynopsis}
+where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding
+\TYPENAME{} specified by Table \ref{stdrmatypes}.
 }
 
 \begin{DeprecateBlock}
@@ -54,15 +54,14 @@ CALL @\FuncDecl{SHMEM\_ALLTOALLS64}@(dest, source, dst, sst, nelems, PE_start, l
     A value of \CONST{1} indicates contiguous data.  \VAR{sst} must be
     of type \CTYPE{ptrdiff\_t}.  When using \Fortran, it must be a
     default integer value.}
-
+\apiargument{IN}{nelems}{The number of elements to exchange for each \ac{PE}.
+    \VAR{nelems} must be of type size\_t for \CorCpp.  When using
+    \Fortran, it must be a default integer value.}
 \newtext{%
 \apiargument{IN}{team}{A valid \openshmem team handle.}
 }
 
 \begin{DeprecateBlock}
-\apiargument{IN}{nelems}{The number of elements to exchange for each \ac{PE}.
-    \VAR{nelems} must be of type size\_t for \CorCpp.  When using
-    \Fortran, it must be a default integer value.}
 \apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set of
     \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
     it must be a default integer value.}
@@ -91,8 +90,8 @@ CALL @\FuncDecl{SHMEM\_ALLTOALLS64}@(dest, source, dst, sst, nelems, PE_start, l
     access in \FUNC{shmem\_alltoall} is always with a stride of \CONST{1}.}
 
     Each \ac{PE} \oldtext{in the active set} \newtext{participating in the operation}
-    exchanges \VAR{nelems} strided data elements of size
-    32 bits (for \FUNC{shmem\_alltoalls32}) or 64 bits (for \FUNC{shmem\_alltoalls64})
+    exchanges \VAR{nelems} strided data elements \oldtext{of size
+    32 bits (for \FUNC{shmem\_alltoalls32}) or 64 bits (for \FUNC{shmem\_alltoalls64})}
     with all other \acp{PE} \oldtext{in the set} \newtext{participating in the operation}.
     Both strides, \VAR{dst} and \VAR{sst}, must be greater
     than or equal to \CONST{1}.
@@ -115,7 +114,6 @@ CALL @\FuncDecl{SHMEM\_ALLTOALLS64}@(dest, source, dst, sst, nelems, PE_start, l
     \begin{itemize}
     \item Rules for \ac{PE} participation in the collective routine.
     \item The pre- and post-conditions for symmetric objects.
-    \item Typing constraints for \dest{} and \source{} data objects.
     \end{itemize}
 }
     
@@ -133,7 +131,7 @@ CALL @\FuncDecl{SHMEM\_ALLTOALLS64}@(dest, source, dst, sst, nelems, PE_start, l
 \begin{apiexamples}
 
 \apicexample
-    {This example shows a \FUNC{shmem\_alltoalls64} on two long elements among
+    {This example shows a \FUNC{shmem\_alltoalls} on two long elements among
     all \acp{PE}.}
     {./example_code/shmem_alltoalls_example.c}
     {}

--- a/content/shmem_alltoalls.tex
+++ b/content/shmem_alltoalls.tex
@@ -131,7 +131,7 @@ CALL @\FuncDecl{SHMEM\_ALLTOALLS64}@(dest, source, dst, sst, nelems, PE_start, l
 \begin{apiexamples}
 
 \apicexample
-    {This example shows a \FUNC{shmem\_alltoalls} on two long elements among
+    {This \Cstd[11] example shows a \FUNC{shmem\_alltoalls} on two 64-bit integers among
     all \acp{PE}.}
     {./example_code/shmem_alltoalls_example.c}
     {}

--- a/content/shmem_barrier_all.tex
+++ b/content/shmem_barrier_all.tex
@@ -36,7 +36,7 @@ CALL @\FuncDecl{SHMEM\_BARRIER\_ALL}@
     \FUNC{shmem\_put\_nbi}, and \FUNC{shmem\_get\_nbi}.
 
 {\color{Green}
-    \FUNC{shmem\_barrier} has been deprecated in favor of the equivalent
+    \FUNC{shmem\_barrier\_all} has been deprecated in favor of the equivalent
     call to \FUNC{shmem\_quiet} followed by a call to
     \FUNC{shmem\_sync(SHMEM\_TEAM\_WORLD)}.
 }

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -8,20 +8,20 @@
 %% C11
 {\color{Green}
 \begin{C11synopsis}
-int @\FuncDecl{shmem\_broadcast32}@(void *dest, const void *source, size_t nelems, int PE_root, shmem_team_t team);
-int @\FuncDecl{shmem\_broadcast64}@(void *dest, const void *source, size_t nelems, int PE_root, shmem_team_t team);
+int @\FuncDecl{shmem\_broadcast}@(TYPE *dest, const TYPE *source, size_t nelems, int PE_root, shmem_team_t team);
 \end{C11synopsis}
+where \TYPE{} is one of the standard \ac{RMA} types specified by Table
+\ref{stdrmatypes}.
 }
 
 %% C/C++
-\begin{Csynopsis}
-\end{Csynopsis}
 {\color{Green}
-\begin{CsynopsisCol}
-int @\FuncDecl{shmem\_team\_broadcast32}@(void *dest, const void *source, size_t nelems, int PE_root, shmem_team_t team);
-int @\FuncDecl{shmem\_team\_broadcast64}@(void *dest, const void *source, size_t nelems, int PE_root, shmem_team_t team);
-\end{CsynopsisCol}
+\begin{Csynopsis}
+int @\FuncDecl{shmem\_team\_\FuncParam{TYPENAME}\_broadcast}@(TYPE *dest, const TYPE *source, size_t nelems, int PE_root, shmem_team_t team);
+\end{Csynopsis}
+where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYPENAME{} specified by Table \ref{stdrmatypes}.
 }
+
 \begin{DeprecateBlock}
 \begin{CsynopsisCol}
 void @\FuncDecl{shmem\_broadcast32}@(void *dest, const void *source, size_t nelems, int PE_root, int PE_start, int logPE_stride, int PE_size, long *pSync);
@@ -40,13 +40,9 @@ CALL @\FuncDecl{SHMEM\_BROADCAST64}@(dest, source, nelems, PE_root, PE_start, lo
  
 \begin{apiarguments}
 
-\apiargument{OUT}{dest}{A symmetric data object. \newtext{See the table below in this description
-    for allowable types.}} 
-\apiargument{IN}{source}{A symmetric data object that can be of any data type
-    that is permissible for the \dest{} argument.}
-\apiargument{IN}{nelems}{The number of elements in \source.  For
-    \FUNC{shmem\_broadcast32} and \FUNC{shmem\_broadcast4}, this is the number of
-    32-bit halfwords.  nelems must be of type \VAR{size\_t} in \Cstd.  When
+\apiargument{OUT}{dest}{\newtext{A remotely accessible data object to be updated by the broadcast operation.}}
+\apiargument{IN}{source}{\newtext{A remotely accessible data object to be broadcast from \VAR{PE\_root}.}}
+    \apiargument{IN}{nelems}{The number of elements in the \newtext{\dest{} and \source{} arrays}.  \oldtext{For \FUNC{shmem\_broadcast32} and \FUNC{shmem\_broadcast4}, this is the number of 32-bit halfwords}.  \VAR{nelems} must be of type \VAR{size\_t} in \Cstd.  When
     using \Fortran, it must be a default integer value.}
 \apiargument{IN}{PE\_root}{Zero-based ordinal of the \ac{PE}, with respect to
     the \newtext{team or} active set, from which the data is copied.
@@ -138,6 +134,7 @@ CALL @\FuncDecl{SHMEM\_BROADCAST64}@(dest, source, nelems, PE_root, PE_start, lo
     \end{itemize}
 }
 
+\begin{DeprecateBlock}
 \apidesctable{
 The  \dest{}  and \source{} data  objects must conform to certain typing
 constraints, which are as follows:
@@ -149,6 +146,7 @@ constraints, which are as follows:
 \apitablerow{shmem\_broadcast4, shmem\_broadcast32}{Any noncharacter
     type that has an element size of \CONST{32} bits. No \Fortran derived types \newtext{nor} \oldtext{or} 
     \CorCpp{} structures are allowed.}
+\end{DeprecateBlock}
 
 \apireturnvalues{
    \newtext{Zero on successful local completion. Nonzero otherwise.}

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -40,8 +40,8 @@ CALL @\FuncDecl{SHMEM\_BROADCAST64}@(dest, source, nelems, PE_root, PE_start, lo
  
 \begin{apiarguments}
 
-\apiargument{OUT}{dest}{\newtext{A remotely accessible data object to be updated by the broadcast operation.}}
-\apiargument{IN}{source}{\newtext{A remotely accessible data object to be broadcast from \VAR{PE\_root}.}}
+\apiargument{OUT}{dest}{\newtext{A symmetric data object to be updated by the broadcast operation.}}
+\apiargument{IN}{source}{\newtext{A symmetric data object to be broadcast from \VAR{PE\_root}.}}
     \apiargument{IN}{nelems}{The number of elements in the \newtext{\dest{} and \source{} arrays}.  \oldtext{For \FUNC{shmem\_broadcast32} and \FUNC{shmem\_broadcast4}, this is the number of 32-bit halfwords}.  \VAR{nelems} must be of type \VAR{size\_t} in \Cstd.  When
     using \Fortran, it must be a default integer value.}
 \apiargument{IN}{PE\_root}{Zero-based ordinal of the \ac{PE}, with respect to
@@ -186,7 +186,7 @@ constraints, which are as follows:
 \begin{apiexamples}
 
 \apicexample
-    {In the following example, the call to \FUNC{shmem\_broadcast64} copies \source{}
+    {In the following \CorCpp{} example, the call to \FUNC{shmem\_team\_broadcast} copies \source{}
     on \ac{PE} $0$ to \dest{} on \acp{PE} $1\dots npes-1$.
     
     \CorCpp{} example:}

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -48,9 +48,9 @@ CALL @\FuncDecl{SHMEM\_FCOLLECT64}@(dest, source, nelems, PE_start, logPE_stride
 
 \begin{apiarguments}
 
-\apiargument{OUT}{dest}{\newtext{A remotely accessible array} large enough
+\apiargument{OUT}{dest}{A symmetric array large enough
     to accept the concatenation of the \source{} arrays on all participating \acp{PE}.}
-\apiargument{IN}{source}{\newtext{The remotely accessible data object to be concatenated.}}
+\apiargument{IN}{source}{\newtext{The symmetric data object to be concatenated.}}
 \apiargument{IN}{nelems}{The number of elements in the \source{} array. \VAR{nelems}
     must be of type \VAR{size\_t} for \Cstd. When using \Fortran, it must be
     a default integer value.}

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -8,22 +8,20 @@
 %% C11
 {\color{Green}
 \begin{C11synopsis}
-int @\FuncDecl{shmem\_collect32}@(void *dest, const void *source, size_t nelems, shmem_team_t team);
-int @\FuncDecl{shmem\_collect64}@(void *dest, const void *source, size_t nelems, shmem_team_t team);
-int @\FuncDecl{shmem\_fcollect32}@(void *dest, const void *source, size_t nelems, shmem_team_t team);
-int @\FuncDecl{shmem\_fcollect64}@(void *dest, const void *source, size_t nelems, shmem_team_t team);
+int @\FuncDecl{shmem\_collect}@(TYPE *dest, const TYPE *source, size_t nelems, shmem_team_t team);
+int @\FuncDecl{shmem\_fcollect}@(TYPE *dest, const TYPE *source, size_t nelems, shmem_team_t team);
 \end{C11synopsis}
+where \TYPE{} is one of the standard \ac{RMA} types specified by Table
+\ref{stdrmatypes}.
 }
 
-\begin{Csynopsis}
-\end{Csynopsis}
 {\color{Green}
-\begin{CsynopsisCol}
-int @\FuncDecl{shmem\_team\_collect32}@(void *dest, const void *source, size_t nelems, shmem_team_t team);
-int @\FuncDecl{shmem\_team\_collect64}@(void *dest, const void *source, size_t nelems, shmem_team_t team);
-int @\FuncDecl{shmem\_team\_fcollect32}@(void *dest, const void *source, size_t nelems, shmem_team_t team);
-int @\FuncDecl{shmem\_team\_fcollect64}@(void *dest, const void *source, size_t nelems, shmem_team_t team);
-\end{CsynopsisCol}
+\begin{Csynopsis}
+int @\FuncDecl{shmem\_team\_\FuncParam{TYPENAME}\_collect}@(TYPE *dest, const TYPE *source, size_t nelems, shmem_team_t team);
+int @\FuncDecl{shmem\_team\_\FuncParam{TYPENAME}\_fcollect}@(TYPE *dest, const TYPE *source, size_t nelems, shmem_team_t team);
+\end{Csynopsis}
+where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding
+\TYPENAME{} specified by Table \ref{stdrmatypes}.
 }
 \begin{DeprecateBlock}
 \begin{CsynopsisCol}
@@ -50,19 +48,17 @@ CALL @\FuncDecl{SHMEM\_FCOLLECT64}@(dest, source, nelems, PE_start, logPE_stride
 
 \begin{apiarguments}
 
-\apiargument{OUT}{dest}{A symmetric array large enough
-    to accept the concatenation of the \source{} arrays on all participating \acp{PE}.
-    \newtext{See table below in this description for allowable data types.}}
-\apiargument{IN}{source}{A symmetric data object that can be of any type permissible
-    for the \dest{} argument.}
+\apiargument{OUT}{dest}{\newtext{A remotely accessible array} large enough
+    to accept the concatenation of the \source{} arrays on all participating \acp{PE}.}
+\apiargument{IN}{source}{\newtext{The remotely accessible data object to be concatenated.}}
 \apiargument{IN}{nelems}{The number of elements in the \source{} array. \VAR{nelems}
     must be of type \VAR{size\_t} for \Cstd. When using \Fortran, it must be
     a default integer value.}
-
 \newtext{%
 \apiargument{IN}{team}{A valid \openshmem team handle.}
 }
 
+\begin{DeprecateBlock}
 \apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set of
     \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
     it must be a default integer value.}
@@ -79,6 +75,7 @@ CALL @\FuncDecl{SHMEM\_FCOLLECT64}@(dest, source, nelems, PE_start, logPE_stride
     Every element of this array must be initialized with the value
     \CONST{SHMEM\_SYNC\_VALUE} before any of the \acp{PE} in the active set
     enter \FUNC{shmem\_collect} or \FUNC{shmem\_fcollect}.}
+\end{DeprecateBlock}
 
 \end{apiarguments}
 
@@ -86,7 +83,7 @@ CALL @\FuncDecl{SHMEM\_FCOLLECT64}@(dest, source, nelems, PE_start, logPE_stride
 {\color{Green}
     \openshmem \FUNC{collect} and \FUNC{fcollect} routines perform a collective
     operation to concatenate \VAR{nelems}
-    \CONST{64}-bit or \CONST{32}-bit data items from the \source{} array into the
+    \oldtext{\CONST{64}-bit or \CONST{32}-bit} data items from the \source{} array into the
     \dest{} array, over an \openshmem team or active set
     in processor number order. The resultant \dest{} array contains the contribution from
     \acp{PE} as follows:
@@ -131,19 +128,6 @@ CALL @\FuncDecl{SHMEM\_FCOLLECT64}@(dest, source, nelems, PE_start, logPE_stride
     \item \newtext{For active-set-based collective routines,} the values in the \VAR{pSync} array are
     restored to the original values.
     \end{itemize}
-}
-
-{\color{Green}
-\apidesctable{
-The  \dest{}  and \source{} data  objects must conform to certain typing
-constraints, which are as follows:
-}{Routine}{Data type of \VAR{dest} and \VAR{source}}
-\apitablerow{\FUNC{shmem\_collect8}, \FUNC{shmem\_collect64}, \FUNC{shmem\_fcollect8}, \FUNC{shmem\_fcollect64}}%
-    {Any noncharacter type that has an element size of \CONST{64} bits. No \Fortran derived types nor
-    \CorCpp{} structures are allowed.}
-\apitablerow{\FUNC{shmem\_collect4}, \FUNC{shmem\_collect32}, \FUNC{shmem\_fcollect4}, \FUNC{shmem\_fcollect32}}%
-    {Any noncharacter type that has an element size of \CONST{32} bits. No \Fortran derived types nor
-    \CorCpp{} structures are allowed.}
 }
 
 \apireturnvalues{

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -452,6 +452,12 @@ CALL @\FuncDecl{SHMEM\_REAL16\_PROD\_TO\_ALL}@(dest, source, nreduce, PE_start, 
 
 \begin{apiexamples}
 
+\apicexample
+    { The following \Cstd[11] example performs a \OPR{SUM} reduction of the
+    integer array \VAR{values} across all PEs:}
+    {./example_code/shmem_sum_example.c}
+    {}
+
 \apifexample
     {This \Fortran reduction example statically initializes the \VAR{pSync} array
     and finds the logical \OPR{AND} of the integer variable \VAR{FOO} across all

--- a/example_code/shmem_alltoall_example.c
+++ b/example_code/shmem_alltoall_example.c
@@ -4,10 +4,6 @@
 
 int main(void)
 {
-   static long pSync[SHMEM_ALLTOALL_SYNC_SIZE];
-   for (int i = 0; i < SHMEM_ALLTOALL_SYNC_SIZE; i++)
-      pSync[i] = SHMEM_SYNC_VALUE;
-
    shmem_init();
    int me = shmem_my_pe();
    int npes = shmem_n_pes();
@@ -23,11 +19,12 @@ int main(void)
          dest[(pe * count) + i] = 9999;
       }
    }
-   /* wait for all PEs to update source/dest */
-   shmem_barrier_all();
+
+   /* wait for all PEs to initialize source/dest: */
+   shmem_sync(SHMEM_TEAM_WORLD);
 
    /* alltoall on all PES */
-   shmem_alltoall64(dest, source, count, 0, 0, npes, pSync);
+   shmem_alltoall(dest, source, count, SHMEM_TEAM_WORLD);
 
    /* verify results */
    for (int pe = 0; pe < npes; pe++) {

--- a/example_code/shmem_alltoalls_example.c
+++ b/example_code/shmem_alltoalls_example.c
@@ -4,10 +4,6 @@
 
 int main(void)
 {
-   static long pSync[SHMEM_ALLTOALLS_SYNC_SIZE];
-   for (int i = 0; i < SHMEM_ALLTOALLS_SYNC_SIZE; i++)
-      pSync[i] = SHMEM_SYNC_VALUE;
-
    shmem_init();
    int me = shmem_my_pe();
    int npes = shmem_n_pes();
@@ -25,11 +21,12 @@ int main(void)
          dest[dst * ((pe * count) + i)] = 9999;
       }
    }
-   /* wait for all PEs to update source/dest */
-   shmem_barrier_all();
+
+   /* wait for all PEs to initialize source/dest: */
+   shmem_sync(SHMEM_TEAM_WORLD);
 
    /* alltoalls on all PES */
-   shmem_alltoalls64(dest, source, dst, sst, count, 0, 0, npes, pSync);
+   shmem_alltoalls(dest, source, dst, sst, count, SHMEM_TEAM_WORLD);
 
    /* verify results */
    for (int pe = 0; pe < npes; pe++) {

--- a/example_code/shmem_broadcast_example.c
+++ b/example_code/shmem_broadcast_example.c
@@ -4,9 +4,6 @@
 
 int main(void)
 {
-   static long pSync[SHMEM_BCAST_SYNC_SIZE];
-   for (int i = 0; i < SHMEM_BCAST_SYNC_SIZE; i++)
-      pSync[i] = SHMEM_SYNC_VALUE;
    static long source[4], dest[4];
 
    shmem_init();
@@ -17,7 +14,7 @@ int main(void)
       for (int i = 0; i < 4; i++)
          source[i] = i;
 
-   shmem_broadcast64(dest, source, 4, 0, 0, 0, npes, pSync);
+   shmem_team_broadcast64(dest, source, 4, 0, SHMEM_TEAM_WORLD);
    printf("%d: %ld, %ld, %ld, %ld\n", me, dest[0], dest[1], dest[2], dest[3]);
    shmem_finalize();
    return 0;

--- a/example_code/shmem_broadcast_example.c
+++ b/example_code/shmem_broadcast_example.c
@@ -14,7 +14,8 @@ int main(void)
       for (int i = 0; i < 4; i++)
          source[i] = i;
 
-   shmem_team_broadcast64(dest, source, 4, 0, SHMEM_TEAM_WORLD);
+   shmem_team_broadcast(dest, source, 4, 0, SHMEM_TEAM_WORLD);
+
    printf("%d: %ld, %ld, %ld, %ld\n", me, dest[0], dest[1], dest[2], dest[3]);
    shmem_finalize();
    return 0;

--- a/example_code/shmem_collect_example.c
+++ b/example_code/shmem_collect_example.c
@@ -23,7 +23,7 @@ int main(void)
    /* Wait for all PEs to initialize source/dest: */
    shmem_team_sync(SHMEM_TEAM_WORLD);
 
-   shmem_team_collect32(dest, source, my_nelem, SHMEM_TEAM_WORLD);
+   shmem_team_collect(dest, source, my_nelem, SHMEM_TEAM_WORLD);
 
    shmem_set_lock(&lock); /* Lock prevents interleaving printfs */
    printf("%d: %d", me, dest[0]);

--- a/example_code/shmem_collect_example.c
+++ b/example_code/shmem_collect_example.c
@@ -5,9 +5,6 @@
 int main(void)
 {
    static long lock = 0;
-   static long pSync[SHMEM_COLLECT_SYNC_SIZE];
-   for (int i = 0; i < SHMEM_COLLECT_SYNC_SIZE; i++)
-      pSync[i] = SHMEM_SYNC_VALUE;
 
    shmem_init();
    int me = shmem_my_pe();
@@ -23,9 +20,10 @@ int main(void)
    for (int i = 0; i < total_nelem; i++)
       dest[i] = -9999;
 
-   shmem_barrier_all(); /* Wait for all PEs to update source/dest */
+   /* Wait for all PEs to initialize source/dest: */
+   shmem_team_sync(SHMEM_TEAM_WORLD);
 
-   shmem_collect32(dest, source, my_nelem, 0, 0, npes, pSync);
+   shmem_team_collect32(dest, source, my_nelem, SHMEM_TEAM_WORLD);
 
    shmem_set_lock(&lock); /* Lock prevents interleaving printfs */
    printf("%d: %d", me, dest[0]);

--- a/example_code/shmem_sum_example.c
+++ b/example_code/shmem_sum_example.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <shmem.h>
+
+#define N 10
+
+int main(void)
+{
+
+   shmem_init();
+   int me = shmem_my_pe();
+   int npes = shmem_n_pes();
+
+   int *values = shmem_malloc(N * sizeof(int));
+   int *sums = shmem_malloc(N * sizeof(int));
+
+   for (int i=0; i < N; i++) {
+      values[i] = me + 1;
+   }
+
+   /* Wait for all PEs to initialize the values array: */
+   shmem_sync(SHMEM_TEAM_WORLD);
+
+   shmem_sum_to_all(sums, values, N, SHMEM_TEAM_WORLD);
+
+   /* Check the result */
+   for (int i = 0; i < N; i++) {
+      if (sums[i] != npes * (npes + 1) / 2) {
+         shmem_global_exit(1);
+      }
+   }
+
+   shmem_free(values);
+   shmem_free(sums);
+   shmem_finalize();
+   return 0;
+}


### PR DESCRIPTION
This PR proposes typed collectives for broadcast, collect/fcollect, and alltoall/alltoalls with corresponding (minimal) examples on `SHMEM_TEAM_WORLD`.  It deprecates the 32/64-bit type constraints on these collectives.  There are also a few minor fixes/edits thrown in that I found while reading.

@gmegan, please review when you have the chance and let me know what you think.  In particular, I imagine we may want examples using collectives over teams other than `SHMEM_TEAM_WORLD`, but I hesitate to make *all* these examples more sophisticated than necessary... 

