### PR TITLE
Update collective examples to match teams API

### DIFF
--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -180,7 +180,7 @@ constraints, which are as follows:
 \begin{apiexamples}
 
 \apicexample
-    {This example shows a \FUNC{shmem\_alltoall64} on two long elements among all
+    {This \CorCpp{} example shows a \FUNC{shmem\_int64\_alltoall} on two 64-bit integers among all
     \acp{PE}.}
     {./example_code/shmem_alltoall_example.c}
     {}

--- a/content/shmem_alltoalls.tex
+++ b/content/shmem_alltoalls.tex
@@ -133,7 +133,7 @@ CALL @\FuncDecl{SHMEM\_ALLTOALLS64}@(dest, source, dst, sst, nelems, PE_start, l
 \begin{apiexamples}
 
 \apicexample
-    {This example shows a \FUNC{shmem\_alltoalls64} on two long elements among
+    {This \CorCpp{} example shows a \FUNC{shmem\_int64\_alltoalls} on two 64-bit integers among
     all \acp{PE}.}
     {./example_code/shmem_alltoalls_example.c}
     {}

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -188,7 +188,7 @@ constraints, which are as follows:
 \begin{apiexamples}
 
 \apicexample
-    {In the following example, the call to \FUNC{shmem\_broadcast64} copies \source{}
+    {In the following \Cstd[11] example, the call to \FUNC{shmem\_broadcast} copies \source{}
     on \ac{PE} $0$ to \dest{} on \acp{PE} $1\dots npes-1$.
     
     \CorCpp{} example:}

--- a/example_code/shmem_alltoall_example.c
+++ b/example_code/shmem_alltoall_example.c
@@ -4,10 +4,6 @@
 
 int main(void)
 {
-   static long pSync[SHMEM_ALLTOALL_SYNC_SIZE];
-   for (int i = 0; i < SHMEM_ALLTOALL_SYNC_SIZE; i++)
-      pSync[i] = SHMEM_SYNC_VALUE;
-
    shmem_init();
    int me = shmem_my_pe();
    int npes = shmem_n_pes();
@@ -23,11 +19,11 @@ int main(void)
          dest[(pe * count) + i] = 9999;
       }
    }
-   /* wait for all PEs to update source/dest */
-   shmem_barrier_all();
+   /* wait for all PEs to initialize source/dest */
+   shmem_team_sync(SHMEM_TEAM_WORLD);
 
    /* alltoall on all PES */
-   shmem_alltoall64(dest, source, count, 0, 0, npes, pSync);
+   shmem_int64_alltoall(SHMEM_TEAM_WORLD, dest, source, count);
 
    /* verify results */
    for (int pe = 0; pe < npes; pe++) {

--- a/example_code/shmem_alltoalls_example.c
+++ b/example_code/shmem_alltoalls_example.c
@@ -4,10 +4,6 @@
 
 int main(void)
 {
-   static long pSync[SHMEM_ALLTOALLS_SYNC_SIZE];
-   for (int i = 0; i < SHMEM_ALLTOALLS_SYNC_SIZE; i++)
-      pSync[i] = SHMEM_SYNC_VALUE;
-
    shmem_init();
    int me = shmem_my_pe();
    int npes = shmem_n_pes();
@@ -25,11 +21,11 @@ int main(void)
          dest[dst * ((pe * count) + i)] = 9999;
       }
    }
-   /* wait for all PEs to update source/dest */
-   shmem_barrier_all();
+   /* wait for all PEs to initialize source/dest */
+   shmem_team_sync(SHMEM_TEAM_WORLD);
 
    /* alltoalls on all PES */
-   shmem_alltoalls64(dest, source, dst, sst, count, 0, 0, npes, pSync);
+   shmem_int64_alltoalls(SHMEM_TEAM_WORLD, dest, source, dst, sst, count);
 
    /* verify results */
    for (int pe = 0; pe < npes; pe++) {

--- a/example_code/shmem_broadcast_example.c
+++ b/example_code/shmem_broadcast_example.c
@@ -4,9 +4,6 @@
 
 int main(void)
 {
-   static long pSync[SHMEM_BCAST_SYNC_SIZE];
-   for (int i = 0; i < SHMEM_BCAST_SYNC_SIZE; i++)
-      pSync[i] = SHMEM_SYNC_VALUE;
    static long source[4], dest[4];
 
    shmem_init();
@@ -17,7 +14,8 @@ int main(void)
       for (int i = 0; i < 4; i++)
          source[i] = i;
 
-   shmem_broadcast64(dest, source, 4, 0, 0, 0, npes, pSync);
+   shmem_broadcast(SHMEM_TEAM_WORLD, dest, source, 4, 0);
+
    printf("%d: %ld, %ld, %ld, %ld\n", me, dest[0], dest[1], dest[2], dest[3]);
    shmem_finalize();
    return 0;

--- a/example_code/shmem_collect_example.c
+++ b/example_code/shmem_collect_example.c
@@ -5,9 +5,6 @@
 int main(void)
 {
    static long lock = 0;
-   static long pSync[SHMEM_COLLECT_SYNC_SIZE];
-   for (int i = 0; i < SHMEM_COLLECT_SYNC_SIZE; i++)
-      pSync[i] = SHMEM_SYNC_VALUE;
 
    shmem_init();
    int me = shmem_my_pe();
@@ -23,9 +20,10 @@ int main(void)
    for (int i = 0; i < total_nelem; i++)
       dest[i] = -9999;
 
-   shmem_barrier_all(); /* Wait for all PEs to update source/dest */
+   /* Wait for all PEs to initialize source/dest: */
+   shmem_team_sync(SHMEM_TEAM_WORLD);
 
-   shmem_collect32(dest, source, my_nelem, 0, 0, npes, pSync);
+   shmem_int_collect(SHMEM_TEAM_WORLD, dest, source, my_nelem);
 
    shmem_set_lock(&lock); /* Lock prevents interleaving printfs */
    printf("%d: %d", me, dest[0]);


### PR DESCRIPTION
These are bare-minimum examples for the collectives to match the latest teams API, as proposed in PRs #94, #96, #97, #98, and #100.

@gmegan Please feel free to supplant these examples (now or later) with something more comprehensive.  I can also split up this PR if it helps on your end.  Also, I believe you can close #84 when ever you're ready.

I'm not including any reduction examples for now.  I created issue #12 so I don't forget.

Signed-off-by: David M. Ozog <david.m.ozog@intel.com>