### PR TITLE
Fix minor issues: shmem_team_translate_pe example

### DIFF
--- a/example_code/shmem_team_translate.c
+++ b/example_code/shmem_team_translate.c
@@ -9,22 +9,23 @@
 
 int main(int argc, char *argv[])
 {
-    int                  rank;
+    int                  rank, npes;
     int                  t_pe;
-    int 		  t_global;
+    int                  t_global;
     shmem_team_t         new_team;
     shmem_team_config_t *config;
 
     shmem_init();
     config = NULL;
     rank   = shmem_my_pe();
+    npes   = shmem_num_pes();
 
     shmem_team_split_strided(SHMEM_TEAM_WORLD, 0, 2, npes / 2, config, 0,
                              &new_team);
 
     if (new_team != SHMEM_TEAM_NULL) {
         t_pe     = shmem_team_my_pe(new_team);
-        t_global = shmem_team_translate(new_team, t_pe, SHMEM_TEAM_WORLD);
+        t_global = shmem_team_translate_pe(new_team, t_pe, SHMEM_TEAM_WORLD);
 
         if (t_global != rank) {
             shmem_global_exit(1);


### PR DESCRIPTION
The `npes` variable is missing, and I fixed a minor spacing issue that affects the LaTeX.

Also, renamed the call from `shmem_team_translate` to `shmem_team_translate_pe` (which is the name we settled on, right?)