### PR TITLE
Fix comparison bug in shmem_sync example w/ teams

### DIFF
--- a/example_code/shmem_sync_example.c
+++ b/example_code/shmem_sync_example.c
@@ -28,14 +28,14 @@ int main(void)
    int my_pe_twos = shmem_team_my_pe(twos_team);
    int my_pe_threes = shmem_team_my_pe(threes_team);
 
-   if (my_pe_twos != SHMEM_TEAM_NULL) {
+   if (twos_team != SHMEM_TEAM_NULL) {
       /* put the value 2 to the next team member in a circular fashion */
       shmem_p(&x, 2, (me + 2) % npes);
       shmem_quiet();
       shmem_sync(twos_team);
    }
 
-   if (my_pe_threes != SHMEM_TEAM_NULL) {
+   if (threes_team != SHMEM_TEAM_NULL) {
       /* put the value 3 to the next team member in a circular fashion */
       shmem_p(&x, 3, (me + 3) % npes);
       shmem_quiet();


### PR DESCRIPTION
This should be comparing the team _handle_ with `SHMEM_TEAM_NULL`, not the PE value (my fault).

Also note that this example is also affected by #115, so we might need to precede the split with something like:
```c
if (npes < 3) {
    printf("This example requires at least 3 PEs\n");
    shmem_global_exit(1);
}
```