### PR TITLE
Match type size in reduce example, add finalize()

### DIFF
--- a/example_code/shmem_reduce_example.c
+++ b/example_code/shmem_reduce_example.c
@@ -23,15 +23,15 @@ int main(void)
   int npes = shmem_n_pes();
   size_t num = 32;
 
-  long *values = shmem_malloc(num * sizeof(int));
-  long *sums = shmem_malloc(num * sizeof(int));
-  
-  unsigned char *valid_me = shmem_malloc(num * sizeof(int));
-  unsigned char *valid_all = shmem_malloc(num * sizeof(int));
+  long *values = shmem_malloc(num * sizeof(long));
+  long *sums = shmem_malloc(num * sizeof(long));
+
+  unsigned char *valid_me = shmem_malloc(num * sizeof(unsigned char));
+  unsigned char *valid_all = shmem_malloc(num * sizeof(unsigned char));
 
   values[0] = recv_a_value((unsigned)me, npes);
   valid_me[0] = is_valid(values[0], npes);
-  
+
   for (int i=1; i < num; i++) {
     values[i] = recv_a_value((unsigned)values[i-1], npes);
     valid_me[i] = is_valid(values[i], npes);
@@ -58,5 +58,7 @@ int main(void)
       printf ("[%d] = invalid on one or more pe\n", i);
     }
   }
+
+  shmem_finalize();
+  return 0;
 }
-  


### PR DESCRIPTION
This fixes a couple minor issues I see in the `shmem_reduce` example code: type size mismatch in `shmem_malloc`, and no call to `shmem_finalize()`.

Another thought is that we do not need the C11 generic version here, since the text says it's a "C/C++ reduction example".  Do you want to remove the check on `STDC_VERSION`?