### PR TITLE
Post-readings (5/21 + 7/22) fixes

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -364,12 +364,6 @@ supported before removal.
     \color{Green}
     \CorCpp: \FuncRef{shmem\_barrier} & 1.5 & Current &
         \FUNC{shmem\_quiet}; \FUNC{shmem\_team\_sync} \\ \hline
-    \color{Green}
-    \CorCpp: \FuncRef{shmem\_barrier\_all} & 1.5 & Current &
-        \FUNC{shmem\_quiet}; \FUNC{shmem\_team\_sync}(\LibConstRef{SHMEM\_TEAM\_WORLD}) \\ \hline
-    \color{Green}
-    \CorCpp: \FuncRef{shmem\_sync\_all} & 1.5 & Current &
-        \FUNC{shmem\_team\_sync}(\LibConstRef{SHMEM\_TEAM\_WORLD}) \\ \hline
 
     \end{longtable}
 \end{center}
@@ -537,18 +531,6 @@ for that particular team. Rather than continue to support \FUNC{shmem\_barrier}
 for active-sets or teams, programs should use a call to \FUNC{shmem\_quiet}
 followed by a call to \FUNC{shmem\_sync} in order to explicitly
 indicate which context to quiesce.
-
-\subsection{\CorCpp: \FUNC{shmem\_barrier\_all}, \FUNC{shmem\_sync\_all}}
-With the addition of \openshmem teams combined, the notion of all \acp{PE} has
-been encapsulated as \LibConstRef{SHMEM\_TEAM\_WORLD}. The previous
-method of specifying active sets to \FUNC{shmem\_barrier} and \FUNC{shmem\_sync}
-was verbose. So, shorthand versions of these functions were helpful both in
-readability and ability to improve performance by not requiring tests of
-active set parameters to determine that the routine involved all \acp{PE}.
-With teams, becomes readable in a program to simply call a barrier or sync
-on \LibConstRef{SHMEM\_TEAM\_WORLD}. Implementations need only test one constant
-to determine that the operation involves all \acp{PE}.
-}
 
 \chapter{Changes to this Document}\label{sec:changelog}
 

--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -166,7 +166,7 @@ constraints, which are as follows:
 \apinotes{
 \newtext{%
     There are no specifically defined error codes for these routines.
-    See section \ref{subsec:error_handling} for expected error checking and
+    See Section~\ref{subsec:error_handling} for expected error checking and
     return code behavior specific to implementations. For portable
     error checking and debugging behavior, programs should do their own checks
     for invalid team handles or \LibConstRef{SHMEM\_TEAM\_INVALID}.

--- a/content/shmem_alltoalls.tex
+++ b/content/shmem_alltoalls.tex
@@ -114,8 +114,8 @@ CALL @\FuncDecl{SHMEM\_ALLTOALLS64}@(dest, source, dst, sst, nelems, PE_start, l
     \ac{PE} \VAR{j}.
 
 {\color{Green}
-    See the description of \FUNC{shmem\_alltoall} in section
-    \ref{subsec:shmem_alltoall} for:
+    See the description of \FUNC{shmem\_alltoall} in
+    Section~\ref{subsec:shmem_alltoall} for:
     \begin{itemize}
     \item Data element sizes for the different sized and typed \FUNC{shmem\_alltoalls} variants.
     \item Rules for \ac{PE} participation in the collective routine.
@@ -132,7 +132,7 @@ CALL @\FuncDecl{SHMEM\_ALLTOALLS64}@(dest, source, dst, sst, nelems, PE_start, l
 }
 
 \apinotes{
-    \newtext{See notes for \FUNC{shmem\_alltoall} in section \ref{subsec:shmem_alltoall}}.
+    \newtext{See notes for \FUNC{shmem\_alltoall} in Section~\ref{subsec:shmem_alltoall}}.
 }
 
 \begin{apiexamples}

--- a/content/shmem_barrier.tex
+++ b/content/shmem_barrier.tex
@@ -58,12 +58,6 @@ CALL @\FuncDecl{SHMEM\_BARRIER}@(PE_start, logPE_stride, PE_size, pSync)
     The  same  \VAR{pSync} array may be reused on consecutive calls   to
     \FUNC{shmem\_barrier} if the same active set is used.
 
-{\color{Green}
-    \FUNC{shmem\_barrier} has been deprecated in favor of the equivalent
-    call to \FUNC{shmem\_quiet} followed by a call to
-    \FUNC{shmem\_sync} on a team or active set with the desired
-    set of \acp{PE}.
-}
 }
 
 \apireturnvalues{
@@ -71,6 +65,16 @@ CALL @\FuncDecl{SHMEM\_BARRIER}@(PE_start, logPE_stride, PE_size, pSync)
 }
 
 \apinotes{
+    \newtext{
+    As of \openshmem[1.5], \FUNC{shmem\_barrier} has been deprecated.
+    No team-based barrier is provided by \openshmem, as a team may have any
+    number of communication contexts associated with the team.
+    Applications seeking such an idiom should call
+    \FUNC{shmem\_ctx\_quiet} on the desired communication context,
+    followed by a call to \FUNC{shmem\_team\_sync} on the desired
+    team.
+    }
+
     If the \VAR{pSync} array is initialized at the run time, all
     \acp{PE} must be synchronized before the first call to \FUNC{shmem\_barrier}
     (e.g., by \FUNC{shmem\_barrier\_all}) to ensure the array has been initialized
@@ -87,14 +91,6 @@ CALL @\FuncDecl{SHMEM\_BARRIER}@(PE_start, logPE_stride, PE_size, pSync)
     Calls to \FUNC{shmem\_ctx\_quiet} can be performed prior
     to calling the barrier routine to ensure completion of operations issued on
     additional contexts.
-
-    \newtext{
-    No team-based barrier is provided by \openshmem, as a team may have any
-    number of communication contexts associated with the team.
-    Applications seeking such an idiom should call \FUNC{shmem\_ctx\_quiet}
-    on the desired context, followed by a call to \FUNC{shmem\_team\_sync}
-    on the desired team.
-    }
 }
 
 \begin{apiexamples}

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -161,7 +161,7 @@ constraints, which are as follows:
 \apinotes{
 \newtext{%
     There are no specifically defined error codes for these routines.
-    See section \ref{subsec:error_handling} for expected error checking and
+    See Section~\ref{subsec:error_handling} for expected error checking and
     return code behavior specific to implementations. For portable
     error checking and debugging behavior, programs should do their own checks
     for invalid team handles or \LibConstRef{SHMEM\_TEAM\_INVALID}

--- a/content/shmem_calloc.tex
+++ b/content/shmem_calloc.tex
@@ -15,7 +15,8 @@ void *@\FuncDecl{shmem\_calloc}@(size_t count, size_t size);
 
 
 \apidescription{
-  The \FUNC{shmem\_calloc} routine is a collective operation that allocates a
+  The \FUNC{shmem\_calloc} routine is a collective operation
+  \newtext{on the default team} that allocates a
   region of remotely-accessible
   memory for an array of \VAR{count} objects of \VAR{size} bytes each and
   returns a pointer to the lowest byte address of the allocated symmetric

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -160,7 +160,7 @@ constraints, which are as follows:
 \apinotes{
 \newtext{%
     There are no specifically defined error codes for these routines.
-    See section \ref{subsec:error_handling} for expected error checking and
+    See Section~\ref{subsec:error_handling} for expected error checking and
     return code behavior specific to implementations. For portable
     error checking and debugging behavior, programs should do their own checks
     for invalid team handles or \LibConstRef{SHMEM\_TEAM\_INVALID}.

--- a/content/shmem_malloc.tex
+++ b/content/shmem_malloc.tex
@@ -23,7 +23,7 @@ void *@\FuncDecl{shmem\_align}@(size_t alignment, size_t size);
 \apidescription{
     The \FUNC{shmem\_malloc}, \FUNC{shmem\_free}, \FUNC{shmem\_realloc}, and
     \FUNC{shmem\_align} routines are collective operations that require
-    participation by all \acp{PE}.
+    participation by all \acp{PE} \newtext{in the default team}.
 
     The \FUNC{shmem\_malloc} routine returns a pointer to a block of at least
     \VAR{size} bytes, which shall be suitably aligned so that it may be

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -437,7 +437,7 @@ CALL @\FuncDecl{SHMEM\_REAL16\_PROD\_TO\_ALL}@(dest, source, nreduce, PE_start, 
 \apinotes{
 \newtext{%
     There are no specifically defined error codes for this routine.
-    See section \ref{subsec:error_handling} for expected error checking and
+    See Section~\ref{subsec:error_handling} for expected error checking and
     return code behavior specific to implementations. For portable
     error checking and debugging behavior, programs should do their own checks
     for invalid team handles or \LibConstRef{SHMEM\_TEAM\_INVALID}

--- a/content/shmem_sync.tex
+++ b/content/shmem_sync.tex
@@ -51,7 +51,7 @@ void @\FuncDecl{shmem\_sync}@(int PE_start, int logPE_stride, int PE_size, long 
 {\color{Green}
     The routine registers the arrival of a \ac{PE} at a synchronization point in the program.
     This is a fast mechanism for synchronizing all \acp{PE} that participate in this
-    collective call. The routine blocks the calling \ac{PE} until all \ac{PE} in the
+    collective call. The routine blocks the calling \ac{PE} until all \acp{PE} in the
     specified team or active set have called \FUNC{shmem\_sync}. In a multithreaded \openshmem
     program, only the calling thread is blocked.
 
@@ -90,7 +90,7 @@ void @\FuncDecl{shmem\_sync}@(int PE_start, int logPE_stride, int PE_size, long 
 
 \newtext{%
     There are no specifically defined error codes for sync operations.
-    See section \ref{subsec:error_handling} for expected error checking and
+    See Section~\ref{subsec:error_handling} for expected error checking and
     return code behavior specific to implementations. For portable
     error checking and debugging behavior, programs should do their own checks
     for invalid team handles or \LibConstRef{SHMEM\_TEAM\_INVALID}

--- a/content/shmem_sync.tex
+++ b/content/shmem_sync.tex
@@ -1,7 +1,11 @@
 \apisummary{
     \newtext{Registers the arrival of a \ac{PE} at a synchronization point and suspends \ac{PE}
     execution until all other \acp{PE} in a given \openshmem team or active set
-    arrive at the same synchronization point.}
+    arrive at a synchronization point.}
+    \oldtext{%
+    Performs all operations described in the \FUNC{shmem\_sync\_all} interface
+    but with respect to a subset of \acp{PE} defined by the active set.
+    }
 }
 
 \begin{apidefinition}
@@ -45,8 +49,13 @@ void @\FuncDecl{shmem\_sync}@(int PE_start, int logPE_stride, int PE_size, long 
 \end{apiarguments}
 
 \apidescription{
-    \FUNC{shmem\_sync} is a collective synchronization routine over
-    \newtext{an existing \openshmem team or} an active set
+    \FUNC{shmem\_sync} is a collective synchronization routine over an
+    \newtext{existing \openshmem team or} active set.
+    \oldtext{%
+    Control returns from \FUNC{shmem\_sync} after all \acp{PE} in
+    the active set (specified by \VAR{PE\_start}, \VAR{logPE\_stride}, and
+    \VAR{PE\_size}) have called \FUNC{shmem\_sync}.
+    }
 
 {\color{Green}
     The routine registers the arrival of a \ac{PE} at a synchronization point in the program.
@@ -84,6 +93,7 @@ void @\FuncDecl{shmem\_sync}@(int PE_start, int logPE_stride, int PE_size, long 
 
 \apireturnvalues{
     \newtext{Zero on successful local completion. Nonzero otherwise.}
+    \oldtext{None.}
 }
 
 \apinotes{

--- a/content/shmem_sync_all.tex
+++ b/content/shmem_sync_all.tex
@@ -1,6 +1,6 @@
 \apisummary{
-    \newtext{Performs all operations described in the \FUNC{shmem\_sync} interface
-    but implicitly operates on \LibConstRef{SHMEM\_TEAM\_WORLD}.}
+    Registers the arrival of a \ac{PE} at a \newtext{synchronization point} \oldtext{barrier} and suspends \ac{PE}
+    execution until all other \acp{PE} \newtext{in the default team} arrive at \newtext{a synchronization point} \oldtext{the barrier}.
 }
 
 \begin{apidefinition}
@@ -16,19 +16,24 @@ void @\FuncDecl{shmem\_sync\_all}@(void);
 \end{apiarguments}
 
 \apidescription{
-{\color{Green}
-    This routine blocks the \ac{PE} until all \acp{PE} in the \openshmem
-    program have called \FUNC{shmem\_sync\_all}. In a multithreaded \openshmem
-    program, only the calling thread is blocked.
+
+  \newtext{%
+    This routine blocks the calling \ac{PE} until all \acp{PE} in the
+    default team have called \FUNC{shmem\_sync\_all}.
+  }
+  \oldtext{%
+    The \FUNC{shmem\_sync\_all} routine registers the arrival of a \ac{PE} at a
+    barrier. Barriers are a fast mechanism for synchronizing all \acp{PE} at
+    once.  This routine blocks the \ac{PE} until all \acp{PE} have called
+    \FUNC{shmem\_sync\_all}.
+  }
+    In a multithreaded \openshmem program, only the calling thread is
+    blocked.
 
     In contrast with the \FUNC{shmem\_barrier\_all} routine,
     \FUNC{shmem\_sync\_all} only ensures completion and visibility of previously issued memory
     stores and does not ensure completion of remote memory updates issued via
     \openshmem routines.
-
-    The \FUNC{shmem\_sync\_all} routine is deprecated in favor of the equivalent call to
-    \FUNC{shmem\_sync(SHMEM\_TEAM\_WORLD)}.
-}
 }
 
 \apireturnvalues{
@@ -36,7 +41,17 @@ void @\FuncDecl{shmem\_sync\_all}@(void);
 }
 
 \apinotes{
-    None.
+  \newtext{%
+    The \FUNC{shmem\_sync\_all} routine is equivalent to calling
+    \FUNC{shmem\_team\_sync} on the default team.
+  }
+  \oldtext{%
+    The \FUNC{shmem\_sync\_all} routine can be used to portably ensure that
+    memory access operations observe remote updates in the order enforced by the
+    initiator \acp{PE}, provided that the initiator PE ensures completion of remote
+    updates with a call to \FUNC{shmem\_quiet} prior to the call to the
+    \FUNC{shmem\_sync\_all} routine.
+  }
 }
 
 \end{apidefinition}

--- a/content/shmem_sync_all.tex
+++ b/content/shmem_sync_all.tex
@@ -1,4 +1,3 @@
-\begin{DeprecateBlock}
 \apisummary{
     \newtext{Performs all operations described in the \FUNC{shmem\_sync} interface
     but implicitly operates on \LibConstRef{SHMEM\_TEAM\_WORLD}.}
@@ -41,4 +40,3 @@ void @\FuncDecl{shmem\_sync\_all}@(void);
 }
 
 \end{apidefinition}
-\end{DeprecateBlock}

--- a/content/shmem_team_split_2d.tex
+++ b/content/shmem_team_split_2d.tex
@@ -65,8 +65,8 @@ new \VAR{yteam}s will contain all \acp{PE} with the same coordinate along the
 
 The \acp{PE} are numbered in the new teams based on the coordinate of the
 \ac{PE} along the given axis. So, another way to think of the result of the split
-operation is that the value returned by \FUNC{shmem\_team\_my\_pe}(\VAR(xteam)) is the
-x-coordinate and the value returned by \FUNC{shmem\_team\_my\_pe}(\VAR(yteam))
+operation is that the value returned by \FUNC{shmem\_team\_my\_pe(\VAR{xteam})} is the
+x-coordinate and the value returned by \FUNC{shmem\_team\_my\_pe(\VAR{yteam})}
 is the y-coordinate of the calling \ac{PE}.
 
 Any valid \openshmem team can be used as the parent team. This routine must be
@@ -82,7 +82,7 @@ configuration parameters.
 The \acp{PE} in the parent team \emph{do not} have to all provide the same
 parameters for new teams.
 
-The \VAR{xaxis\_mask} and\VAR{xaxis\_mask} arguments are a bitwise masks
+The \VAR{xaxis\_mask} and \VAR{yaxis\_mask} arguments are a bitwise masks
 representing the set of configuration parameters to use from
 \VAR{xaxis\_config} and \VAR{yaxis\_config}, respectively.
 A mask value of \CONST{0} indicates that the team

--- a/content/shmem_team_split_2d.tex
+++ b/content/shmem_team_split_2d.tex
@@ -8,8 +8,8 @@ and \emph{y}-dimensions.}
 
 \begin{Csynopsis}
 int @\FuncDecl{shmem\_team\_split\_2d}@(shmem_team_t parent_team, int xrange,
-     shmem_team_config_t *xaxis_config, long xaxis_mask, shmem_team_t *xaxis_team,
-     shmem_team_config_t *yaxis_config, long yaxis_mask, shmem_team_t *yaxis_team);
+    const shmem_team_config_t *xaxis_config, long xaxis_mask, shmem_team_t *xaxis_team,
+    const shmem_team_config_t *yaxis_config, long yaxis_mask, shmem_team_t *yaxis_team);
 \end{Csynopsis}
 
 \begin{apiarguments}
@@ -19,7 +19,7 @@ int @\FuncDecl{shmem\_team\_split\_2d}@(shmem_team_t parent_team, int xrange,
 \apiargument{IN}{xrange}{A nonnegative integer representing the number of
 elements in the first dimension.}
 
-\apiargument{INOUT}{xaxis\_config}{
+\apiargument{IN}{xaxis\_config}{
   A pointer to the configuration parameters for the new \VAR{x}-axis team.}
 
 \apiargument{IN}{xaxis\_mask}{
@@ -30,7 +30,7 @@ elements in the first dimension.}
 subset consisting of all the \acp{PE} that have the same coordinate along the \VAR{x}-axis
 as the calling \ac{PE}.}
 
-\apiargument{INOUT}{yaxis\_config}{
+\apiargument{IN}{yaxis\_config}{
   A pointer to the configuration parameters for the new \VAR{y}-axis team.}
 
 \apiargument{IN}{yaxis\_mask}{

--- a/content/shmem_team_split_2d.tex
+++ b/content/shmem_team_split_2d.tex
@@ -72,7 +72,7 @@ is the y-coordinate of the calling \ac{PE}.
 Any valid \openshmem team can be used as the parent team. This routine must be
 called by all \acp{PE} in the parent team. The value of \VAR{xrange} must be
 nonnegative and all \acp{PE} in the parent team must pass the same value for
-\VAR{xrange}. None of the parameters need to reside in symmetric memory.
+\VAR{xrange}.
 
 The \VAR{xaxis\_config} and \VAR{yaxis\_config} arguments specify team
 configuration parameters for the \VAR{x}- and \VAR{y}-axis teams, respectively.

--- a/content/shmem_team_split_strided.tex
+++ b/content/shmem_team_split_strided.tex
@@ -6,8 +6,8 @@ where the subset is defined by the
 \begin{apidefinition}
 
 \begin{Csynopsis}
-int @\FuncDecl{shmem\_team\_split\_strided}@(shmem_team_t parent_team, int start, int stride,
-     int size, const shmem_team_config_t *config, long config_mask, shmem_team_t *new_team);
+int @\FuncDecl{shmem\_team\_split\_strided}@(shmem_team_t parent_team, int start, int stride, int size,
+    const shmem_team_config_t *config, long config_mask, shmem_team_t *new_team);
 \end{Csynopsis}
 
 \begin{apiarguments}
@@ -51,13 +51,18 @@ A valid triplet is one such that:
 \end{equation*}
 where $N$ is the number of \acp{PE} in the parent team.
 
-This routine must be called by all \acp{PE} contained in the \ac{PE} triplet
-specification. It may be called by additional \acp{PE} not included in the
-triplet specification, but for those \acp{PE} a \VAR{new\_team} value of
-\LibConstRef{SHMEM\_TEAM\_INVALID} is returned. All \acp{PE} must provide the
-same values for the \ac{PE} triplet. This routine will return a \VAR{new\_team}
-containing the \ac{PE} subset specified by the triplet and ordered by the
-existing global \ac{PE} number.
+This routine must be called by all \acp{PE} in the parent team.
+All \acp{PE} must provide the same values for the \ac{PE} triplet.
+This routine will return a \VAR{new\_team} containing the \ac{PE}
+subset specified by the triplet and ordered by the existing global
+\ac{PE} number.
+
+On successful creation of the new team, the \VAR{new\_team} handle
+will reference a valid team for the subset of \acp{PE} in the parent
+team specified by the triplet.
+Those \acp{PE} in the parent team that are not in the subset specified
+by the triplet will have \VAR{new\_team} assigned to
+\LibConstRef{SHMEM\_TEAM\_INVALID}.
 
 The \VAR{config} argument specifies team configuration parameters, which are
 described in Section~\ref{subsec:shmem_team_config_t}.
@@ -74,7 +79,8 @@ compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID}, then no new team
 will be created and \VAR{new\_team} will be assigned the value
 \LibConstRef{SHMEM\_TEAM\_INVALID}; otherwise, the behavior is undefined.
 
-If an invalid \ac{PE} triplet is provided, then the \VAR{new\_team} will not be created.
+If an invalid \ac{PE} triplet is provided, then the \VAR{new\_team}
+will not be created.
 
 If \VAR{new\_team} cannot be created, then it will be assigned the value
 \LibConstRef{SHMEM\_TEAM\_INVALID}.

--- a/content/teams_intro.tex
+++ b/content/teams_intro.tex
@@ -1,11 +1,11 @@
 The \acp{PE} in an \openshmem program communicate using either
-\ac{RMA} and \ac{AMO} routines, which specify the \ac{PE} number of the target
+point-to-point routines---such as \ac{RMA} and \ac{AMO} routines---which specify the \ac{PE} number of the target
 \ac{PE}, or collective routines, which operate over a set of \acp{PE}.
 In \openshmem, teams allow programs to group a set of \acp{PE} for
 communication.
 Team-based collective communications operate across all the \acp{PE}
 in a valid team.
-\ac{RMA} and \ac{AMO} communication can make use of team-relative \ac{PE}
+Point-to-point communication can make use of team-relative \ac{PE}
 numbering through team-based contexts (see Section~\ref{sec:ctx}) or
 \ac{PE} number translation.
 
@@ -27,7 +27,7 @@ All valid teams have a least one member.
 
 A ``team handle'' is an opaque object with type \CTYPE{shmem\_team\_t}
 that is used to reference a team.
-Team handles are not remotely accessible objects
+Team handles are not remotely accessible objects.
 The predefined teams may be accessed via the team handles listed in
 Section~\ref{subsec:library_handles}.
 

--- a/example_code/shmem_team_context.c
+++ b/example_code/shmem_team_context.c
@@ -15,7 +15,7 @@ int my_ctx_translate_pe(shmem_ctx_t src_ctx, int src_pe, shmem_ctx_t dest_ctx)
   shmem_team_t src_team, dest_team;
   shmem_ctx_get_team(src_ctx, &src_team);
   shmem_ctx_get_team(dest_ctx, &dest_team);
-  return shmem_team_translate(src_team, src_pe, dest_pe);
+  return shmem_team_translate_pe(src_team, src_pe, dest_pe);
 }
 
 shmem_ctx_t my_team_create_ctx(shmem_team_t team) {


### PR DESCRIPTION
- Consolidate deprecation rationale for `shmem_barrier` (closes #138)
- Make `shmem_team_split_strided` collective across parent (closes #137)
- Fixes for config args in `shmem_team_split_2d` (closes #135)
- Un-deprecates `shmem_sync_all`
- Restores PDF change highlighting for `shmem_sync[_all]`
- Editorial, formatting, and typo fixes
