### PR TITLE
Change team_split2D example comment to latex prose

### DIFF
--- a/content/shmem_team_split_2d.tex
+++ b/content/shmem_team_split_2d.tex
@@ -145,7 +145,100 @@ See the description of team handles and predefined teams at the top of section
     to generate a 3D Cartesian split. This method can be extrapolated to
     generate splits of any number of dimensions.}
     {./example_code/shmem_team_split_2D.c}
-    {}
+    {
+    The example above splits \LibHandleRef{SHMEM\_TEAM\_WORLD} into a 3D team
+    with dimensions 3x4xN.  For example, if \VAR{npes} = 16,  \VAR{xdim} = 3,
+    and \VAR{ydim} = 4, then the final dimensions are 3x4x2.  In this case, the
+    first split of \LibHandleRef{SHMEM\_TEAM\_WORLD} results in 6 \VAR{xteams}
+    and 3 \VAR{yzteams}:
+
+    \begin{center}
+    \begin{tabular}{|l|l|l|l|l|}
+     \hline
+      \multicolumn{2}{|c|}{} & \multicolumn{3}{c|}{\VAR{yzteam}} \\ \cline{3-5}
+      \multicolumn{2}{|c|}{} & \VAR{x} = 0 & \VAR{x} = 1 & \VAR{x} = 2  \\ \hline
+\multirow{6}{*}{\VAR{xteam}} & \VAR{yz} = 0  & 0   & 1   & 2  \\ \cline{2-5}
+                             & \VAR{yz} = 1  & 3   & 4   & 5  \\ \cline{2-5}
+                             & \VAR{yz} = 2  & 6   & 7   & 8  \\ \cline{2-5}
+                             & \VAR{yz} = 3  & 9   & 10 &  11 \\ \cline{2-5}
+                             & \VAR{yz} = 4  & 12  & 13 & 14  \\ \cline{2-5}
+                             & \VAR{yz} = 5  & 15  \\
+     \cline{0-2}
+    \end{tabular}
+    \end{center}
+
+    The second split of \VAR{yzteam} for \VAR{x} = 0, \VAR{ydim} = 4 results in 2
+    \VAR{yteams} and 4 \VAR{zteams}:
+
+
+    \begin{center}
+    \begin{tabular}{|l|l|l|l|l|l|}
+     \hline
+      \multicolumn{2}{|c|}{} & \multicolumn{4}{c|}{\VAR{zteam}} \\ \cline{3-6}
+      \multicolumn{2}{|c|}{} & \VAR{y} = 0 & \VAR{y} = 1 & \VAR{y} = 2 & \VAR{y} = 3 \\ \hline
+\multirow{2}{*}{\VAR{yteam}} & \VAR{z} = 0  & 0    & 3    & 6  & 9 \\ \cline{2-6}
+                             & \VAR{z} = 1  & 12   & 15 \\
+     \cline{0-3}
+    \end{tabular}
+    \end{center}
+
+    The second split of \VAR{yzteam} for \VAR{x} = 1, \VAR{ydim} = 4 results in
+    2 \VAR{yteams} and 4 \VAR{zteams}:
+
+    \begin{center}
+    \begin{tabular}{|l|l|l|l|l|l|}
+     \hline
+      \multicolumn{2}{|c|}{} & \multicolumn{4}{c|}{\VAR{zteam}} \\ \cline{3-6}
+      \multicolumn{2}{|c|}{} & \VAR{y} = 0 & \VAR{y} = 1 & \VAR{y} = 2 & \VAR{y} = 3 \\ \hline
+\multirow{2}{*}{\VAR{yteam}} & \VAR{z} = 0  & 1    & 4    & 7  & 10 \\ \cline{2-6}
+                             & \VAR{z} = 1  & 13 \\
+     \cline{0-2}
+    \end{tabular}
+    \end{center}
+
+    The second split of \VAR{yzteam} for \VAR{x} = 2, \VAR{ydim} = 4 results in
+    2 \VAR{yteams} and 4 \VAR{zteams}:
+
+    \begin{center}
+    \begin{tabular}{|l|l|l|l|l|l|}
+     \hline
+      \multicolumn{2}{|c|}{} & \multicolumn{4}{c|}{\VAR{zteam}} \\ \cline{3-6}
+      \multicolumn{2}{|c|}{} & \VAR{y} = 0 & \VAR{y} = 1 & \VAR{y} = 2 & \VAR{y} = 3 \\ \hline
+\multirow{2}{*}{\VAR{yteam}} & \VAR{z} = 0  & 2    & 5    & 8  & 11 \\ \cline{2-6}
+                             & \VAR{z} = 1  & 14 \\
+     \cline{0-2}
+    \end{tabular}
+    \end{center}
+
+    The final number of teams for each dimension are:
+    \begin{itemize}
+        \item 6 \VAR{xteams}: these are teams where (\VAR{z},\VAR{y}) is fixed and \VAR{x} varies.
+        \item 6 \VAR{yteams}: these are teams where (\VAR{x},\VAR{z}) is fixed and \VAR{y} varies.
+        \item 12 \VAR{zteams}: these are teams where (\VAR{x},\VAR{y}) is fixed and \VAR{z} varies.
+    \end{itemize}
+
+    The expected output is: \\
+    \begin{small}
+    \texttt{
+    (0, 0, 0) is me = 0  \\
+    (1, 0, 0) is me = 1  \\
+    (2, 0, 0) is me = 2  \\
+    (0, 1, 0) is me = 3  \\
+    (1, 1, 0) is me = 4  \\
+    (2, 1, 0) is me = 5  \\
+    (0, 2, 0) is me = 6  \\
+    (1, 2, 0) is me = 7  \\
+    (2, 2, 0) is me = 8  \\
+    (0, 3, 0) is me = 9  \\
+    (1, 3, 0) is me = 10 \\
+    (2, 3, 0) is me = 11 \\
+    (0, 0, 1) is me = 12 \\
+    (1, 0, 1) is me = 13 \\
+    (2, 0, 1) is me = 14 \\
+    (0, 1, 1) is me = 15
+    }
+    \end{small}
+}
 
 \end{apiexamples}
 

--- a/example_code/shmem_team_split_2D.c
+++ b/example_code/shmem_team_split_2D.c
@@ -1,11 +1,11 @@
 #include <stdio.h>
 #include <shmem.h>
 
-int main(void) 
+int main(void)
 {
   int xdim = 3;
   int ydim = 4;
-  
+
   shmem_init();
   int pe = shmem_my_pe();
   int npes = shmem_n_pes();
@@ -15,9 +15,9 @@ int main(void)
     exit(1);
   }
 
-  int zdim = (npes / (xdim*ydim)) + ( ((npes % (xdim*ydim)) > 0) ? 1 : 0 ); 
+  int zdim = (npes / (xdim*ydim)) + ( ((npes % (xdim*ydim)) > 0) ? 1 : 0 );
   shmem_team_t xteam, yzteam, yteam, zteam;
-  
+
   shmem_team_split_2d(SHMEM_TEAM_WORLD, xdim, NULL, 0, &xteam, NULL, 0, &yzteam);
   // No synchronization is needed between these split operations
   // yzteam is immediately ready to be used in collectives
@@ -41,81 +41,3 @@ int main(void)
 
   shmem_finalize();
 }
-
-
-/*
-/* Example split of SHMEM_TEAM_WORLD, size 16 into 3D
-/* xdim = 3, ydim = 4 -> final dimensions are 3x4x2
-/* 
-/* First split of SHMEM_TEAM_WORLD, xdim=3
-/* results in 6 xteams and 3 yzteam
-/**********************************************
-/*        x=0 | x=1 | x=2 |
-/*      -------------------
-/* yz=0 |   0 |   1 |   2 | <-- xteam
-/* yz=1 |   3 |   4 |   5 | <-- xteam
-/* yz=2 |   6 |   7 |   8 | <-- xteam
-/* yz=3 |   9 |  10 |  11 | <-- xteam
-/* yz=4 |  12 |  13 |  14 | <-- xteam
-/* yz=5 |  15 |           | <-- xteam
-/*         ^      ^     ^
-/*         { yzteams are columns }
-/**********************************************
-/*
-/* Second split of yzteam for x=0, ydim=4
-/* results in 2 yteams and 4 zteams
-/**********************************************
-/*       y=0 | y=1 | y=2 | y=3 |
-/*     -------------------------
-/* z=0 |   0 |   3 |   6 |   9 | <-- yteam
-/* z=1 |  12 |  15 |           | <-- yteam
-/*         ^     ^     ^     ^
-/*         { zteams are columns }
-/**********************************************
-/*
-/* Second split of yzteam for x=1, ydim=4
-/* results in 2 yteams and 4 zteams
-/**********************************************
-/*       y=0 | y=1 | y=2 | y=3 |
-/*     -------------------------
-/* z=0 |   1 |   4 |   7 |  10 | <-- yteam
-/* z=1 |  13 |     |           | <-- yteam
-/*         ^     ^     ^     ^
-/*         { zteams are columns }
-/**********************************************
-/*
-/* Second split of yzteam for x=2, ydim=4
-/* results in 2 yteams and 4 zteams
-/**********************************************
-/*       y=0 | y=1 | y=2 | y=3 |
-/*     -------------------------
-/* z=0 |   2 |   5 |   8 |  11 | <-- yteam
-/* z=1 |  14 |     |           | <-- yteam
-/*         ^     ^     ^     ^
-/*         { zteams are columns }
-/**********************************************
-/*
-/* Final number of teams for each dimension:
-/* 6 xteams, these are teams where (z,y) is fixed and x varies
-/* 6 yteams, these are teams where (x,z) is fixed and y varies
-/* 12 zteams, these are teams where (x,y) is fixed and z varies
-/*
-/* Expected output:
-/* (0, 0, 0) is me = 0
-/* (1, 0, 0) is me = 1
-/* (2, 0, 0) is me = 2
-/* (0, 1, 0) is me = 3
-/* (1, 1, 0) is me = 4
-/* (2, 1, 0) is me = 5
-/* (0, 2, 0) is me = 6
-/* (1, 2, 0) is me = 7
-/* (2, 2, 0) is me = 8
-/* (0, 3, 0) is me = 9
-/* (1, 3, 0) is me = 10
-/* (2, 3, 0) is me = 11
-/* (0, 0, 1) is me = 12
-/* (1, 0, 1) is me = 13
-/* (2, 0, 1) is me = 14
-/* (0, 1, 1) is me = 15
-*/
-

--- a/utils/packages.tex
+++ b/utils/packages.tex
@@ -3,6 +3,7 @@
 \usepackage[utf8]{inputenc}
 \usepackage{graphicx}
 \usepackage{multicol}
+\usepackage{multirow}
 \usepackage[normalem]{ulem}
 \usepackage{float}
 \usepackage[usenames,dvipsnames]{color}


### PR DESCRIPTION
This updates the long comment on the `shmem_team_split_2d` example to use Latex tables.  I changed the prose a bit to be more readable, so please check the wording and the table values for correctness.  Thanks!

Signed-off-by: David M. Ozog <david.m.ozog@intel.com>