### PR TITLE
Relax the definition of SHMEM_TEAM_SHARED

### DIFF
--- a/content/library_handles.tex
+++ b/content/library_handles.tex
@@ -24,7 +24,7 @@ See Section~\ref{subsec:team} for more detail about its use.
 \LibHandleDecl{SHMEM\_TEAM\_SHARED} &
 Handle of type \CTYPE{shmem\_team\_t} that corresponds to a team of \acp{PE}
 that share a memory domain. When this handle is used by some \ac{PE},
-it will refer to the team of all \acp{PE} that would return a non-null
+it will refer to a team of one or more \acp{PE} that would return a non-null
 pointer from \FUNC{shmem\_ptr} for symmetric objects on that \ac{PE},
 and vice versa. This means that symmetric objects on each \ac{PE} are
 directly load/store accessible by all \acp{PE} in the team.


### PR DESCRIPTION
This changes SHMEM_TEAM_SHARED to include only a subset of the PEs that are accessible via 1shmem_ptr`, not necessarily all of them.