### PR TITLE
Clarify return value w/ invalid team_split_strided

### DIFF
--- a/content/shmem_team_split_strided.tex
+++ b/content/shmem_team_split_strided.tex
@@ -74,16 +74,16 @@ should be created with the default values for all configuration parameters.
 See Section~\ref{subsec:shmem_team_config_t} for field mask names and
 default configuration parameters.
 
-When \VAR{parent\_team} specifies an invalid team, if \VAR{parent\_team}
+If \VAR{parent\_team}
 compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID}, then no new team
 will be created and \VAR{new\_team} will be assigned the value
-\LibConstRef{SHMEM\_TEAM\_INVALID}; otherwise, the behavior is undefined.
+\LibConstRef{SHMEM\_TEAM\_INVALID}.  If \VAR{parent\_team} is otherwise invalid, the behavior is undefined.
 
 If an invalid \ac{PE} triplet is provided, then the \VAR{new\_team}
 will not be created.
 
 If \VAR{new\_team} cannot be created, then it will be assigned the value
-\LibConstRef{SHMEM\_TEAM\_INVALID}.
+\LibConstRef{SHMEM\_TEAM\_INVALID} and \FUNC{shmem\_team\_split\_strided} will return a nonzero value.
 }
 
 \apireturnvalues{


### PR DESCRIPTION
The first change attempts to clarify what happens when `parent_team` is invalid - I find the original sentence a little difficult to parse.  Is this better?

I'm also unsure whether setting `new_team` to `SHMEM_TEAM_INVALID` is a "successful" creation of `new_team` and whether the return value should be nonzero.  Either way is fine with me, but in this PR I assume this case is "unsuccessful", so a nonzero value is returned.